### PR TITLE
upgrade webview crypto fixes breaking error with eval

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "encode-utf8": "^1.0.2",
     "fast-base64-encode": "^1.0.0",
-    "webview-crypto": "^0.1.10"
+    "webview-crypto": "^0.1.11"
   },
   "peerDependencies": {
     "react": ">=16.4",


### PR DESCRIPTION
This upgrade by webview-crypto team fixes an error when creating a new ArrayBuffer uwing the `eval` javascript method.

This error prevents login and authentication of all kinds.